### PR TITLE
In the ScalaTest matcher, show the actual value first

### DIFF
--- a/src/main/scala/org/scalatest/xml/XmlMatchers.scala
+++ b/src/main/scala/org/scalatest/xml/XmlMatchers.scala
@@ -28,7 +28,7 @@ trait XmlMatchers {
       val res = if(ignoreWhitespace) (e =#= a).successful else (e =?= a).successful
       MatchResult(
         res,
-        s"""$e isn't equal to $a""",
+        s"""$a was not equal to $e""",
         s"""both xml are equal""")
     }
   }


### PR DESCRIPTION
Similarly to how built-in ScalaTest matchers work.