### PR TITLE
Make diffing stack safe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,9 @@ licenses ++= Seq(
   ("GPL-3.0", url("https://www.gnu.org/licenses/gpl-3.0.html")),
   ("LGPL-3.0", url("https://www.gnu.org/licenses/lgpl-3.0.html")))
 
+Test / fork := true
+Test / javaOptions += "-Xss256K"
+
 homepage := Some(url("http://github.com/andyglow/scala-xml-diff"))
 
 startYear := Some(2017)

--- a/src/main/scala/com/github/andyglow/xml/diff/Eval.scala
+++ b/src/main/scala/com/github/andyglow/xml/diff/Eval.scala
@@ -43,7 +43,7 @@ package com.github.andyglow.xml.diff
 
 import scala.util.control.TailCalls._
 
-sealed abstract class Eval[+A] extends Serializable { self =>
+private[diff] sealed abstract class Eval[+A] extends Serializable { self =>
   def value: A
 
   def map[B](f: A => B): Eval[B] =
@@ -72,7 +72,7 @@ sealed abstract class Eval[+A] extends Serializable { self =>
     }
 }
 
-object Eval {
+private[diff] object Eval {
   final case class Now[A](value: A) extends Eval[A]
 
   def now[A](a: A): Eval[A] = Now(a)

--- a/src/main/scala/com/github/andyglow/xml/diff/Eval.scala
+++ b/src/main/scala/com/github/andyglow/xml/diff/Eval.scala
@@ -1,0 +1,72 @@
+package com.github.andyglow.xml.diff
+
+import scala.util.control.TailCalls._
+
+sealed abstract class Eval[+A] extends Serializable { self =>
+  def value: A
+
+  def map[B](f: A => B): Eval[B] =
+    flatMap(a => Eval.Now(f(a)))
+
+  def flatMap[B](f: A => Eval[B]): Eval[B] =
+    this match {
+      case c: Eval.Now[A] =>
+        new Eval.FlatMap[B] {
+          type Start = A
+          val start = () => self
+          val run = f
+        }
+
+      case c: Eval.FlatMap[A] =>
+        new Eval.FlatMap[B] {
+          type Start = c.Start
+          val start: () => Eval[Start] = c.start
+          val run: Start => Eval[B] = (s: c.Start) =>
+            new Eval.FlatMap[B] {
+              type Start = A
+              val start = () => c.run(s)
+              val run = f
+            }
+        }
+    }
+}
+
+object Eval {
+  final case class Now[A](value: A) extends Eval[A]
+
+  def now[A](a: A): Eval[A] = Now(a)
+
+  sealed abstract class FlatMap[A] extends Eval[A] { self =>
+    type Start
+    val start: () => Eval[Start]
+    val run: Start => Eval[A]
+
+    def value: A = evaluate(this)
+  }
+
+  sealed abstract private class FnStack[A, B]
+  final private case class Ident[A, B](ev: A <:< B) extends FnStack[A, B]
+  final private case class Many[A, B, C](first: A => Eval[B], rest: FnStack[B, C]) extends FnStack[A, C]
+
+  private def evaluate[A](e: Eval[A]): A = {
+    def loop[A1](curr: Eval[A1], fs: FnStack[A1, A]): TailRec[A] =
+      curr match {
+        case c: FlatMap[A1] =>
+          c.start() match {
+            case cc: FlatMap[c.Start] =>
+              tailcall(loop(cc.start(), Many(cc.run, Many(c.run, fs))))
+
+            case xx: Now[c.Start] =>
+              tailcall(loop(c.run(xx.value), fs))
+          }
+
+        case x: Now[A1] =>
+          fs match {
+            case Many(f, fs) => tailcall(loop(f(x.value), fs))
+            case Ident(ev)   => done(ev(x.value))
+          }
+      }
+
+    loop(e, Ident(implicitly[A <:< A])).result
+  }
+}

--- a/src/main/scala/com/github/andyglow/xml/diff/Eval.scala
+++ b/src/main/scala/com/github/andyglow/xml/diff/Eval.scala
@@ -1,3 +1,44 @@
+/**
+ * scala-xml-diff
+ * Copyright (c) 2014, Andrey Onistchuk, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ *
+ * ------
+ *
+ * This code is derived from cats. The cats license follows:
+ *
+ * Cats Copyright (c) 2015 Cats Contributors.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.andyglow.xml.diff
 
 import scala.util.control.TailCalls._

--- a/src/main/scala/com/github/andyglow/xml/diff/package.scala
+++ b/src/main/scala/com/github/andyglow/xml/diff/package.scala
@@ -23,11 +23,11 @@ package object diff {
   implicit class XmlOps[T <: xml.NodeSeq](val e: T) extends AnyVal {
 
     def =?=(a: T): XmlDiff = {
-      XmlDiffComputer.computeMatching(e, a)
+      XmlDiffComputer.computeMatching(e, a).value
     }
 
     def =#=(a: T)(implicit ev: T <:< xml.Node): XmlDiff = {
-      XmlDiffComputer.computeMatching(xml.Utility.trim(e), xml.Utility.trim(a))
+      XmlDiffComputer.computeMatching(xml.Utility.trim(e), xml.Utility.trim(a)).value
     }
   }
 

--- a/src/test/scala/com/github/andyglow/xml/diff/XmlDiffSpec.scala
+++ b/src/test/scala/com/github/andyglow/xml/diff/XmlDiffSpec.scala
@@ -107,6 +107,13 @@ class XmlDiffSpec extends AnyWordSpec {
           UnequalElem("baz", List(AbsentNode(<bar/>), RedundantNode(<bax/>)))))))
     }
 
+    "be stack safe" in {
+      def xml(numChildren: Int) = <element>{1.to(numChildren).map(_ => <i/>)}</element>
+
+      (xml(999) =?= xml(1000)) mustBe (
+        Neq(List(UnequalElem("element", List(RedundantNode(<i/>))))))
+    }
+
   }
 
 }


### PR DESCRIPTION
Fixes #14 

- Adds minimal version of [`cats.Eval`](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/Eval.scala) which guarantees stack safety when using `map`/`flatMap`
- Updates all methods in `XmlDiffComputer` to wrap their results in `Eval`
- Sets the JVM stack size when running tests to 256K and adds a test to verify that diffing elements with a lot of children does not throw a `StackOverflowError`